### PR TITLE
Add insecure ssl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Name     | Description | Default value | Environment variable name
 `--influx.url` | Url to InfluxDB | `http://localhost:8086` | `INFLUX_URL`
 `--influx.user` | Username for InfluxDB | _(Not set)_ | `INFLUX_USER`
 `--influx.password` | Password for InfluxDB | _(Not set)_ | `INFLUX_PASSWORD`
-`--ssl.skipVerify` | Skip HTTPS certificate verification | `false` | -
+`--ssl.skip-verify` | Skip HTTPS certificate verification | `false` | -
 `--log.level` | Log level for console output | `info` | -
 `--web.listen-address` | Address on which to expose metrics | `:9424` | -
 `--web.metrics-path` | Path under which the metrics are available | `/metrics` | -

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Name     | Description | Default value | Environment variable name
 `--influx.url` | Url to InfluxDB | `http://localhost:8086` | `INFLUX_URL`
 `--influx.user` | Username for InfluxDB | _(Not set)_ | `INFLUX_USER`
 `--influx.password` | Password for InfluxDB | _(Not set)_ | `INFLUX_PASSWORD`
+`--ssl.skipVerify` | Skip HTTPS certificate verification | `false` | -
 `--log.level` | Log level for console output | `info` | -
 `--web.listen-address` | Address on which to expose metrics | `:9424` | -
 `--web.metrics-path` | Path under which the metrics are available | `/metrics` | -

--- a/exporter.go
+++ b/exporter.go
@@ -40,7 +40,7 @@ var (
 	influxUrl      = kingpin.Flag("influx.url", "Url to InfluxDB").Default("http://localhost:8086").Envar("INFLUX_URL").URL()
 	influxUser     = kingpin.Flag("influx.user", "InfluxDB username").Default("").Envar("INFLUX_USER").String()
 	influxPassword = kingpin.Flag("influx.password", "InfluxDB password").Default("").Envar("INFLUX_PASSWORD").String()
-	sslSkipVerify  = kingpin.Flag("ssl.skipVerify", "Skip HTTPS certificate verification").Default("false").String()
+	sslSkipVerify  = kingpin.Flag("ssl.skip-verify", "Skip HTTPS certificate verification").Default("false").String()
 	bindAddr       = kingpin.Flag("web.listen-address", "Address to serve metrics on").Default(":9424").String()
 	metricsPath    = kingpin.Flag("web.metrics-path", "Path to serve metrics on").Default("/metrics").String()
 	logLevel       = kingpin.Flag("log.level", "Log level").Default(levelString(logrus.InfoLevel)).Enum(levelStrings(logrus.AllLevels)...)

--- a/exporter.go
+++ b/exporter.go
@@ -40,7 +40,7 @@ var (
 	influxUrl      = kingpin.Flag("influx.url", "Url to InfluxDB").Default("http://localhost:8086").Envar("INFLUX_URL").URL()
 	influxUser     = kingpin.Flag("influx.user", "InfluxDB username").Default("").Envar("INFLUX_USER").String()
 	influxPassword = kingpin.Flag("influx.password", "InfluxDB password").Default("").Envar("INFLUX_PASSWORD").String()
-	sslSkipVerify  = kingpin.Flag("ssl.skip-verify", "Skip HTTPS certificate verification").Default("false").String()
+	sslSkipVerify  = kingpin.Flag("ssl.skip-verify", "Skip HTTPS certificate verification").Bool()
 	bindAddr       = kingpin.Flag("web.listen-address", "Address to serve metrics on").Default(":9424").String()
 	metricsPath    = kingpin.Flag("web.metrics-path", "Path to serve metrics on").Default("/metrics").String()
 	logLevel       = kingpin.Flag("log.level", "Log level").Default(levelString(logrus.InfoLevel)).Enum(levelStrings(logrus.AllLevels)...)
@@ -118,9 +118,7 @@ func buildConfig() influx.HTTPConfig {
 	if *influxPassword != "" {
 		config.Password = *influxPassword
 	}
-	if strings.ToLower(*sslSkipVerify) == "true" {
-		config.InsecureSkipVerify = true
-	}
+	config.InsecureSkipVerify = *sslSkipVerify
 
 	return config
 }

--- a/exporter.go
+++ b/exporter.go
@@ -40,6 +40,7 @@ var (
 	influxUrl      = kingpin.Flag("influx.url", "Url to InfluxDB").Default("http://localhost:8086").Envar("INFLUX_URL").URL()
 	influxUser     = kingpin.Flag("influx.user", "InfluxDB username").Default("").Envar("INFLUX_USER").String()
 	influxPassword = kingpin.Flag("influx.password", "InfluxDB password").Default("").Envar("INFLUX_PASSWORD").String()
+	sslSkipVerify  = kingpin.Flag("ssl.skipVerify", "Skip HTTPS certificate verification").Default("false").String()
 	bindAddr       = kingpin.Flag("web.listen-address", "Address to serve metrics on").Default(":9424").String()
 	metricsPath    = kingpin.Flag("web.metrics-path", "Path to serve metrics on").Default("/metrics").String()
 	logLevel       = kingpin.Flag("log.level", "Log level").Default(levelString(logrus.InfoLevel)).Enum(levelStrings(logrus.AllLevels)...)
@@ -116,6 +117,9 @@ func buildConfig() influx.HTTPConfig {
 	}
 	if *influxPassword != "" {
 		config.Password = *influxPassword
+	}
+	if strings.ToLower(*sslSkipVerify) == "true" {
+		config.InsecureSkipVerify = true
 	}
 
 	return config


### PR DESCRIPTION
Hello, 

I have some InfluxDB instances that are using SSL, but the necessary root certificate chain is not present by default.  This PR provides a way to set InsecureSkipVerify in the InfluxDB client to allow it to connect over SSL without trying to verify the server certificate.